### PR TITLE
It should only run the CI as a pre-check for the PR and then when app…

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,9 +1,6 @@
 name: CD
 
 on:
-  # workflow_run:
-  #   workflows: [ CI ]
-  #   types: [ completed ]
   push:
     branches: [ main ]
 
@@ -49,6 +46,3 @@ jobs:
 #
 # Encrypted secrets
 # - https://docs.github.com/en/actions/security-guides/encrypted-secrets
-#
-# Events that trigger workflows > workflow_run
-# - https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run


### PR DESCRIPTION
…roved, it should run the CD